### PR TITLE
Create 2016_04_18_mangos.sql

### DIFF
--- a/sql/nostreborn/updates/mangos/2016_04_18_mangos.sql
+++ b/sql/nostreborn/updates/mangos/2016_04_18_mangos.sql
@@ -1,0 +1,1 @@
+UPDATE `creature_template` SET `UnitClass`="2" WHERE `Entry`="6250"

--- a/sql/nostreborn/updates/mangos/2016_04_18_mangos.sql
+++ b/sql/nostreborn/updates/mangos/2016_04_18_mangos.sql
@@ -1,1 +1,2 @@
-UPDATE `creature_template` SET `UnitClass`="2" WHERE `Entry`="6250"
+UPDATE `creature_template` SET `UnitClass`="2" WHERE `Entry`="6250";
+UPDATE `gameobject_template` SET `flags`="4" WHERE `entry`="7923";


### PR DESCRIPTION
Changed class of an entity to remove rage bar and allow for crowd control spells, fixed "Invalid Target" error upon attempting to cast spells like polymorph.
